### PR TITLE
support diff of lists with duplicate elements

### DIFF
--- a/lib/src/json_patch.dart
+++ b/lib/src/json_patch.dart
@@ -119,8 +119,12 @@ class JsonPatch {
       return [];
     }
 
-    final commonSuffixLength =
-        _getCommonPrefix(newList.reversed.toList(), oldList.reversed.toList());
+    final oldListWithoutPrefix = oldList.sublist(commonPrefixLength);
+    final newListWithoutPrefix = newList.sublist(commonPrefixLength);
+
+    final commonSuffixLength = _getCommonPrefix(
+        oldListWithoutPrefix.reversed.toList(),
+        newListWithoutPrefix.reversed.toList());
 
     final oldListTrimmed = oldList.sublist(
         commonPrefixLength, oldList.length - commonSuffixLength);

--- a/test/json_patch_test.dart
+++ b/test/json_patch_test.dart
@@ -260,6 +260,14 @@ void main() {
       _checkPatch(result[0], 'remove', '/2');
     });
 
+    test('.diff should handle lists with duplicate elements', () {
+      final oldJson = [6];
+      final newJson = [6, 6];
+      final result = JsonPatch.diff(oldJson, newJson);
+      expect(result, hasLength(1));
+      _checkPatch(result[0], 'add', '/-', value: 6);
+    });
+
     test('.diff should handle a equal lists', () {
       final oldJson = [1, 2, 3, 4, 5];
       final newJson = [1, 2, 3, 4, 5];


### PR DESCRIPTION
`diff()` works with `[6]` vs `[6, 7]`, but crashes with `[6]` vs `[6, 6]`. It's because the current code allows  `prefix length + suffix length > total length` so we hit a `RangeError`. This PR fixes that by computing the common suffix length on the lists **after stripping the common prefix** from them.