### PR TITLE
Rename 'to' to 'path' in copy and move operations to conform with spe…

### DIFF
--- a/lib/src/json_patch.dart
+++ b/lib/src/json_patch.dart
@@ -269,14 +269,14 @@ class JsonPatch {
         return fakeParent[fakeChild];
       case 'copy':
         final from = _extractPath(patch, 'from');
-        final to = _extractPath(patch, 'to');
+        final to = _extractPath(patch);
         final fakeTo =
             JsonPointer.join(JsonPointer.fromSegments([fakeChild]), to);
         _addChild(fakeParent, fakeTo, from.traverse(json), strict);
         return fakeParent[fakeChild];
       case 'move':
         final from = _extractPath(patch, 'from');
-        final to = _extractPath(patch, 'to');
+        final to = _extractPath(patch);
         final fakeFrom =
             JsonPointer.join(JsonPointer.fromSegments([fakeChild]), from);
         final fakeTo =

--- a/test/json_patch_test.dart
+++ b/test/json_patch_test.dart
@@ -304,7 +304,7 @@ void main() {
       final result = JsonPatch.apply({
         'a': 5
       }, [
-        {'op': 'copy', 'from': '/a', 'to': '/b'}
+        {'op': 'copy', 'from': '/a', 'path': '/b'}
       ]);
       expect(
           result,
@@ -317,7 +317,7 @@ void main() {
       final result = JsonPatch.apply({
         'a': 5
       }, [
-        {'op': 'move', 'from': '/a', 'to': '/b'}
+        {'op': 'move', 'from': '/a', 'path': '/b'}
       ]);
       expect(
           result,
@@ -381,20 +381,6 @@ void main() {
                 'test': 5
               }, [
                 {'op': 'remove', 'path': '/a'}
-              ]),
-          throwsA(anything));
-      expect(
-          () => JsonPatch.apply({
-                'test': 5
-              }, [
-                {'op': 'move', 'path': '/a', 'to': '/b'}
-              ]),
-          throwsA(anything));
-      expect(
-          () => JsonPatch.apply({
-                'test': 5
-              }, [
-                {'op': 'copy', 'path': '/a', 'to': '/b'}
               ]),
           throwsA(anything));
     });


### PR DESCRIPTION
Copy and move operations use 'path' as the 'to' field rather than using a 'to' field. Have amended this and refactored the surrounding tests. 

See https://tools.ietf.org/html/rfc6902#section-4.4 and https://tools.ietf.org/html/rfc6902#section-4.5

Raised an issue for this: https://github.com/pikaju/dart-json-patch/issues/8